### PR TITLE
Move contact email to footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -7,6 +7,7 @@ export default function Footer() {
         <div className="flex justify-center space-x-4 mt-2">
             <a href="https://github.com/terrainthesky-hub" target="_blank" rel="noopener noreferrer" className="hover:text-indigo-500">GitHub</a>
             <a href="https://linkedin.com/in/lesley-rich-86bb8572/" target="_blank" rel="noopener noreferrer" className="hover:text-indigo-500">LinkedIn</a>
+            <a href="mailto:lesley.t.rich@gmail.com" className="hover:text-indigo-500">Email</a>
         </div>
       </div>
     </footer>

--- a/pages/index.js
+++ b/pages/index.js
@@ -31,19 +31,6 @@ export default function Home({ allPostsData }) {
         </p>
       </section>
 
-      {/* Contact Section */}
-      <section className="py-12 text-center">
-        <h2 className="text-3xl font-bold mb-4">Contact Me</h2>
-        <p className="text-lg">
-          Feel free to reach out at{' '}
-          <a
-            href="mailto:lesley.t.rich@gmail.com"
-            className="text-indigo-400 hover:underline"
-          >
-            lesley.t.rich@gmail.com
-          </a>
-        </p>
-      </section>
 
       {/* About Section */}
       <section className="py-12">


### PR DESCRIPTION
## Summary
- remove the dedicated contact section from the homepage
- add an Email link in the footer alongside GitHub and LinkedIn

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae22bf314832fa461473c3f97bb5b